### PR TITLE
fixed deployment branch

### DIFF
--- a/.github/workflows/demo_site.yml
+++ b/.github/workflows/demo_site.yml
@@ -1,48 +1,46 @@
-name: Build and Deploy Demo Site
+name: Deploy to GitHub Pages
 
 on:
-  # Run this workflow manually from the Actions tab
+  push:
+    branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  deploy_demo_site:
-    runs-on: "ubuntu-latest"
-    env:
-      BUNDLE_PATH: "vendor/bundle"
-      BUNDLE_JOBS: 4
-      BUNDLE_RETRY: 3
+  build:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-        with:
-          repository: jekyll/minima
-          ref: demo-site
-      - name: Set up Ruby 2.7
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: '3.3'
           bundler-cache: true
-      - name: Clone target branch
-        run: |
-          REMOTE_BRANCH="${REMOTE_BRANCH:-gh-pages}"
-          REMOTE_REPO="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
-
-          echo "Publishing to ${GITHUB_REPOSITORY} on branch ${REMOTE_BRANCH}"
-          rm -rf _site/
-          git clone --depth=1 --branch="${REMOTE_BRANCH}" --single-branch --no-checkout "${REMOTE_REPO}" _site/
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - name: Build site
-        run: bundle exec jekyll build --verbose --trace
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
-        run: |
-          SOURCE_COMMIT="$(git log -1 --pretty="%an: %B" "$GITHUB_SHA")"
-          pushd _site &>/dev/null
-          : > .nojekyll
-
-          git add --all
-          git -c user.name="${GITHUB_ACTOR}" -c user.email="${GITHUB_ACTOR}@users.noreply.github.com" \
-            commit --quiet \
-            --message "Deploy demo-site from ${GITHUB_SHA}" \
-            --message "$SOURCE_COMMIT"
-          git push
-
-          popd &>/dev/null
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+mohamedamin.com


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Migrate demo site deployment to GitHub Pages workflow**
> 
> - Replace custom Jekyll deploy script with official Pages actions: `configure-pages`, `upload-pages-artifact`, and `deploy-pages`
> - Trigger on `push` to `main`; add explicit `permissions` and `concurrency` for Pages
> - Split into `build` (Ruby 3.3, `bundle` cache, `jekyll build` with `JEKYLL_ENV=production`) and `deploy` jobs
> - Update `CNAME` to `mohamedamin.com` (ensures proper custom domain)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 089571262b3be7053373f23c288d3e963390b11b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->